### PR TITLE
fix: :bug: fix postmessage from webview to Meso window

### DIFF
--- a/@meso-network/meso-react-native/index.tsx
+++ b/@meso-network/meso-react-native/index.tsx
@@ -96,11 +96,15 @@ export const MesoTransfer = ({
             );
 
             if (webViewRef.current) {
-              webViewRef.current.postMessage(
-                JSON.stringify({
+              const data = JSON.stringify({
                   kind: MessageKind.RETURN_SIGNED_MESSAGE_RESULT,
                   payload: { signedMessage: result },
-                })
+              });
+
+              // Post message back to the Meso window from the webview.
+              // https://github.com/react-native-webview/react-native-webview/blob/4a506e366a3f2e3b08b156d547bd118381e2f6b9/docs/Guide.md#the-injectjavascript-method
+              webViewRef.current.injectJavaScript(
+                `window.postMessage(${data})`
               );
             }
           } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "meso-react-native",
       "version": "1.0.0",
       "dependencies": {
-        "@meso-network/meso-js": "^0.0.78",
+        "@meso-network/meso-js": "^0.1.9",
         "expo": "~50.0.8",
         "expo-status-bar": "~1.11.1",
         "react": "18.2.0",
@@ -3574,9 +3574,9 @@
       }
     },
     "node_modules/@meso-network/meso-js": {
-      "version": "0.0.78",
-      "resolved": "https://registry.npmjs.org/@meso-network/meso-js/-/meso-js-0.0.78.tgz",
-      "integrity": "sha512-gvZIgBG+KKPchAHVruIqjTTfDh/BJYQk6TE2vxLrBBtNc+CarhWJWDAu+JzxU6wiPD2PML25pmHZRC6WRGIcnw=="
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@meso-network/meso-js/-/meso-js-0.1.9.tgz",
+      "integrity": "sha512-wzWywqga8jU2tNCZbc51pk/m8VSOIYG/V2HPKDjwjVq/M0JhBzktuUicnojUu5T4OKRPejqYfwT6ZjyBWZFQPg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@meso-network/meso-js": "^0.0.78",
+    "@meso-network/meso-js": "^0.1.9",
     "expo": "~50.0.8",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",


### PR DESCRIPTION
This fixes a bug in the integration where postMessages could not be sent from the webView to the Meso window on Android.

Previously, we were calling the `postMessage` method directly on the `<WebView>` ref that we held. Instead, on Android, we need to follow the ([documented](https://github.com/react-native-webview/react-native-webview/blob/4a506e366a3f2e3b08b156d547bd118381e2f6b9/docs/Guide.md#the-injectjavascript-method)) pattern for sending postMessage events.

This also upgrades [@meso-network/meso-js](https://github.com/meso-network/meso-js) to the latest version.